### PR TITLE
Add react-tag-names to "related" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Yields:
 *   [`svg-tag-names`](https://github.com/wooorm/svg-tag-names)
     — List of SVG tags
 *   [`react-tag-names`](https://github.com/jgierer12/react-tag-names)
-    — List of React's HTML and SVG tag names
+    — List of React’s HTML and SVG tag names
 *   [`svg-element-attributes`](https://github.com/wooorm/svg-element-attributes)
     — Map of SVG elements to allowed attributes
 *   [`html-element-attributes`](https://github.com/wooorm/html-element-attributes)

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,8 @@ Yields:
     — List of MathML tags
 *   [`svg-tag-names`](https://github.com/wooorm/svg-tag-names)
     — List of SVG tags
+*   [`react-tag-names`](https://github.com/jgierer12/react-tag-names)
+    — List of React's HTML and SVG tag names
 *   [`svg-element-attributes`](https://github.com/wooorm/svg-element-attributes)
     — Map of SVG elements to allowed attributes
 *   [`html-element-attributes`](https://github.com/wooorm/html-element-attributes)


### PR DESCRIPTION
I maintain a similar list of React's supported tag names.